### PR TITLE
Rename metrics to names needed for evalAI leaderboard.

### DIFF
--- a/evaluation_script/main.py
+++ b/evaluation_script/main.py
@@ -6,9 +6,9 @@ from .ground_truth import GroundTruth
 def calculate_query_level_metrics(query_level_metrics, ground_truth):
     """Calculates query level metrics from query level base metrics.
 
-    Query level metrics include recall, precision, and similar metrics. 
-    These are calculated on a per-query basis. A set of metrics 
-    averaged across all queries is calculated and returned in a tuple. 
+    Query level metrics include recall, precision, and similar metrics.
+    These are calculated on a per-query basis. A set of metrics
+    averaged across all queries is calculated and returned in a tuple.
 
     Base metrics includes counts like true positives, false positives, etc. These are
     calculated while walking the predictions.
@@ -49,19 +49,19 @@ def calculate_base_metrics(prediction_file, ground_truth):
     Each query-document pair in the prediction file is examined one-at-a-time. Each
     prediction is compared to the value in ground_truth object from the ground_truth file.
 
-    Base metrics are counts of true positives, false positives, etc. They are computed 
-    both globaly and per-query. Aggregate base metrics (stored in the Metrics class object) and 
+    Base metrics are counts of true positives, false positives, etc. They are computed
+    both globaly and per-query. Aggregate base metrics (stored in the Metrics class object) and
     per-query base metrics (stored in the query_level_metrics dictionary) are returned in a tuple.
     """
     global_metrics = Metrics(False)
     query_level_metrics = {}
     for query_id in ground_truth.queries_with_ground_truth:
         query_level_metrics[query_id] = Metrics(True)
-        
+
     # Predicted_keys serves dual purpose.
     # 1. Prevents the case where a (query_id, doc_id) pair is present multiple times.
     # 2. Helps us penalize those (query_id, doc_id) pairs that are present in ground truth
-    #    but are absent in the prediction file (unlikely though) 
+    #    but are absent in the prediction file (unlikely though)
     predicted_keys = set()
     with open_file(prediction_file) as f:
         header = f.readline().strip("\n").split("\t")
@@ -81,7 +81,7 @@ def calculate_base_metrics(prediction_file, ground_truth):
                             query_level_metrics[query_id].add_prediction(truth_label, prediction_label,
                                                                          doc_id, doc_price)
 
-    # An unlikely case where (query_id, doc_id) pairs are present in 
+    # An unlikely case where (query_id, doc_id) pairs are present in
     # the ground truth but are absent in the prediction file
     for (query_id, doc_id) in ground_truth.querydoc_labels.keys():
         if (query_id, doc_id) not in predicted_keys:
@@ -115,10 +115,10 @@ def evaluate_submission(ground_truth_file, prediction_file, doc_file=None):
     # We populate query_level_base_metrics with queries with any judgements as keys.
     # This will be zero if ground truth file is all empty or no queries are judged.
     # Note that this test prevents all base metrics to be zero after calculate_base_metrics().
-        
+
     if len(ground_truth.queries_with_ground_truth) > 0:
         extension = get_file_extension(prediction_file)
-        if extension == "tsv" or extension == "gz": 
+        if extension == "tsv" or extension == "gz":
             (global_metrics, query_level_metrics) = calculate_base_metrics(prediction_file, ground_truth)
             precision = global_metrics.precision()
             recall = global_metrics.recall()
@@ -129,20 +129,20 @@ def evaluate_submission(ground_truth_file, prediction_file, doc_file=None):
                 calculate_query_level_metrics(query_level_metrics, ground_truth)
 
     return {
-        "global_precision": precision,
-        "global_recall": recall,
-        "global_f1": f1,
-        "global_tpr": recall,
-        "global_fpr": fpr,
-        "global_accuracy": accuracy,
-        "average_precision": qa_precision,
-        "average_recall": qa_recall,
-        "average_f1": qa_f1,
-        "average_tpr": qa_recall,
-        "average_fpr": qa_fpr,
-        "average_accuracy": qa_accuracy,
-        "average_l2h_ndcg@10": qa_l2h_ndcg10,
-        "average_h2l_ndcg@10": qa_h2l_ndcg10
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "tpr": recall,
+        "fpr": fpr,
+        "accuracy": accuracy,
+        "ave_precision": qa_precision,
+        "ave_recall": qa_recall,
+        "ave_f1": qa_f1,
+        "ave_tpr": qa_recall,
+        "ave_fpr": qa_fpr,
+        "ave_accuracy": qa_accuracy,
+        "l2h_ndcg10": qa_l2h_ndcg10,
+        "h2l_ndcg10": qa_h2l_ndcg10
     }
 
 def evaluate(test_annotation_file, user_submission_file, phase_codename, **kwargs):

--- a/tests.py
+++ b/tests.py
@@ -4,20 +4,20 @@ import unittest
 class TestPredictions(unittest.TestCase):
 
     def test_g1_p1(self):
-        expected = {'global_precision': 0.6,
-                    'global_recall': 0.75, 
-                    'global_f1': 0.6666666666666665,
-                    'global_tpr': 0.75,
-                    'global_fpr': 0.6666666666666666,
-                    'global_accuracy': 0.5714285714285714,
-                    'average_precision': 0.7777777777777777,
-                    'average_recall': 0.8333333333333334,
-                    'average_f1': 0.7222222222222222,
-                    'average_tpr': 0.8333333333333334,
-                    'average_fpr': 0.6666666666666666,
-                    'average_accuracy': 0.611111111111111,
-                    'average_l2h_ndcg@10': 0.7169361380260636,
-                    'average_h2l_ndcg@10': 0.7959842760619721,
+        expected = {'precision': 0.6,
+                    'recall': 0.75,
+                    'f1': 0.6666666666666665,
+                    'tpr': 0.75,
+                    'fpr': 0.6666666666666666,
+                    'accuracy': 0.5714285714285714,
+                    'ave_precision': 0.7777777777777777,
+                    'ave_recall': 0.8333333333333334,
+                    'ave_f1': 0.7222222222222222,
+                    'ave_tpr': 0.8333333333333334,
+                    'ave_fpr': 0.6666666666666666,
+                    'ave_accuracy': 0.611111111111111,
+                    'l2h_ndcg10': 0.7169361380260636,
+                    'h2l_ndcg10': 0.7959842760619721,
         }
 
         r = evaluation_script.evaluate("testfiles/ground_truth_set1.tsv",
@@ -29,7 +29,7 @@ class TestPredictions(unittest.TestCase):
                                                        "testfiles/predictions_set1a.tsv",
                                                        "testfiles/documents_set1.tsv")
         for k, v in expected.items():
-            if k != 'average_l2h_ndcg@10' and k != 'average_h2l_ndcg@10':
+            if k != 'l2h_ndcg10' and k != 'h2l_ndcg10':
                 self.assertAlmostEqual(v, rdata[k])
                 self.assertAlmostEqual(v, rdata2[k])
             self.assertAlmostEqual(v, rdata3[k])
@@ -43,7 +43,7 @@ class TestPredictions(unittest.TestCase):
                                                        "testfiles/predictions_set1b.tsv",
                                                        "testfiles/documents_set1.tsv")
         for k, v in expected.items():
-            if k != 'average_l2h_ndcg@10' and k != 'average_h2l_ndcg@10':
+            if k != 'l2h_ndcg10' and k != 'h2l_ndcg10':
                 self.assertAlmostEqual(v, rdata[k])
                 self.assertAlmostEqual(v, rdata2[k])
             self.assertAlmostEqual(v, rdata3[k])
@@ -58,28 +58,28 @@ class TestPredictions(unittest.TestCase):
                                                        "testfiles/predictions_set1a_compressed.tsv.gz",
                                                        "testfiles/documents_set1_compressed.tsv.gz")
         for k, v in expected.items():
-            if k != 'average_l2h_ndcg@10' and k != 'average_h2l_ndcg@10':
+            if k != 'l2h_ndcg10' and k != 'h2l_ndcg10':
                 self.assertAlmostEqual(v, rdata[k])
                 self.assertAlmostEqual(v, rdata2[k])
             self.assertAlmostEqual(v, rdata3[k])
 
     def test_g2_p2a(self):
-        expected = {'global_precision': 0.5,
-                    'global_recall': 1.0,
-                    'global_f1': 0.6666666666666666,
-                    'global_tpr': 1.0,
-                    'global_fpr': 1.0,
-                    'global_accuracy': 0.5,
-                    'average_precision': 0.5,
-                    'average_recall': 1.0,
-                    'average_f1': 0.619047619,
-                    'average_tpr': 1.0,
-                    'average_fpr': 1.0,
-                    'average_accuracy': 0.5,
-                    'average_l2h_ndcg@10': 0.9971792416440344,
-                    'average_h2l_ndcg@10': 0.6830002811190978,
+        expected = {'precision': 0.5,
+                    'recall': 1.0,
+                    'f1': 0.6666666666666666,
+                    'tpr': 1.0,
+                    'fpr': 1.0,
+                    'accuracy': 0.5,
+                    'ave_precision': 0.5,
+                    'ave_recall': 1.0,
+                    'ave_f1': 0.619047619,
+                    'ave_tpr': 1.0,
+                    'ave_fpr': 1.0,
+                    'ave_accuracy': 0.5,
+                    'l2h_ndcg10': 0.9971792416440344,
+                    'h2l_ndcg10': 0.6830002811190978,
         }
-        
+
         r = evaluation_script.evaluate("testfiles/ground_truth_set2.tsv",
                                        "testfiles/predictions_set2a.tsv", "supervised")
         rdata = r['result'][0]['data']
@@ -89,28 +89,28 @@ class TestPredictions(unittest.TestCase):
                                                        "testfiles/predictions_set2a.tsv",
                                                        "testfiles/documents_set2.tsv")
         for k, v in expected.items():
-            if k != 'average_l2h_ndcg@10' and k != 'average_h2l_ndcg@10':
+            if k != 'l2h_ndcg10' and k != 'h2l_ndcg10':
                 self.assertAlmostEqual(v, rdata[k])
                 self.assertAlmostEqual(v, rdata2[k])
             self.assertAlmostEqual(v, rdata3[k])
 
     def test_g2_p2b(self):
-        expected = {'global_precision': 1,
-                    'global_recall': 0.0,
-                    'global_f1': 0.0,
-                    'global_tpr': 0.0,
-                    'global_fpr': 0.0,
-                    'global_accuracy': 0.5,
-                    'average_precision': 1.0,
-                    'average_recall': 0.142857143,
-                    'average_f1': 0.0,
-                    'average_tpr': 0.142857143,
-                    'average_fpr': 0.142857143,
-                    'average_accuracy': 0.5,
-                    'average_l2h_ndcg@10': 0.14285714285714285,
-                    'average_h2l_ndcg@10': 0.14285714285714285,
+        expected = {'precision': 1,
+                    'recall': 0.0,
+                    'f1': 0.0,
+                    'tpr': 0.0,
+                    'fpr': 0.0,
+                    'accuracy': 0.5,
+                    'ave_precision': 1.0,
+                    'ave_recall': 0.142857143,
+                    'ave_f1': 0.0,
+                    'ave_tpr': 0.142857143,
+                    'ave_fpr': 0.142857143,
+                    'ave_accuracy': 0.5,
+                    'l2h_ndcg10': 0.14285714285714285,
+                    'h2l_ndcg10': 0.14285714285714285,
         }
-        
+
         r = evaluation_script.evaluate("testfiles/ground_truth_set2.tsv",
                                        "testfiles/predictions_set2b.tsv", "supervised")
         rdata = r['result'][0]['data']
@@ -120,26 +120,26 @@ class TestPredictions(unittest.TestCase):
                                                        "testfiles/predictions_set2b.tsv",
                                                        "testfiles/documents_set2.tsv")
         for k, v in expected.items():
-            if k != 'average_l2h_ndcg@10' and k != 'average_h2l_ndcg@10':
+            if k != 'l2h_ndcg10' and k != 'h2l_ndcg10':
                 self.assertAlmostEqual(v, rdata[k])
                 self.assertAlmostEqual(v, rdata2[k])
             self.assertAlmostEqual(v, rdata3[k])
 
     def test_g2_p2c(self):
-        expected = {'global_precision': 0.0,
-                    'global_recall': 0.0,
-                    'global_f1': 0,
-                    'global_tpr': 0.0,
-                    'global_fpr': 1.0,
-                    'global_accuracy': 0.0,
-                    'average_precision': 0.142857143,
-                    'average_recall': 0.142857143,
-                    'average_f1': 0.0,
-                    'average_tpr': 0.142857143,
-                    'average_fpr': 1.0,
-                    'average_accuracy': 0.0,
-                    'average_l2h_ndcg@10': 0.9971792416440344,
-                    'average_h2l_ndcg@10': 0.6830002811190978,
+        expected = {'precision': 0.0,
+                    'recall': 0.0,
+                    'f1': 0,
+                    'tpr': 0.0,
+                    'fpr': 1.0,
+                    'accuracy': 0.0,
+                    'ave_precision': 0.142857143,
+                    'ave_recall': 0.142857143,
+                    'ave_f1': 0.0,
+                    'ave_tpr': 0.142857143,
+                    'ave_fpr': 1.0,
+                    'ave_accuracy': 0.0,
+                    'l2h_ndcg10': 0.9971792416440344,
+                    'h2l_ndcg10': 0.6830002811190978,
         }
 
         r = evaluation_script.evaluate("testfiles/ground_truth_set2.tsv",
@@ -151,28 +151,28 @@ class TestPredictions(unittest.TestCase):
                                                        "testfiles/predictions_set2c.tsv",
                                                        "testfiles/documents_set2.tsv")
         for k, v in expected.items():
-            if k != 'average_l2h_ndcg@10' and k != 'average_h2l_ndcg@10':
+            if k != 'l2h_ndcg10' and k != 'h2l_ndcg10':
                 self.assertAlmostEqual(v, rdata[k])
                 self.assertAlmostEqual(v, rdata2[k])
             self.assertAlmostEqual(v, rdata3[k])
 
     def test_g2_p2d(self):
-        expected = {'global_precision': 0.625,
-                    'global_recall': 0.625,
-                    'global_f1': 0.625,
-                    'global_tpr': 0.625,
-                    'global_fpr': 0.375,
-                    'global_accuracy': 0.625,
-                    'average_precision': 0.6666666666666666,
-                    'average_recall': 0.714285714,
-                    'average_f1': 0.585714286,
-                    'average_tpr': 0.714285714,
-                    'average_fpr': 0.428571429,
-                    'average_accuracy': .6547619047619048,
-                    'average_l2h_ndcg@10': 0.8070645353018062,
-                    'average_h2l_ndcg@10': 0.6555242102166945,
+        expected = {'precision': 0.625,
+                    'recall': 0.625,
+                    'f1': 0.625,
+                    'tpr': 0.625,
+                    'fpr': 0.375,
+                    'accuracy': 0.625,
+                    'ave_precision': 0.6666666666666666,
+                    'ave_recall': 0.714285714,
+                    'ave_f1': 0.585714286,
+                    'ave_tpr': 0.714285714,
+                    'ave_fpr': 0.428571429,
+                    'ave_accuracy': .6547619047619048,
+                    'l2h_ndcg10': 0.8070645353018062,
+                    'h2l_ndcg10': 0.6555242102166945,
         }
-        
+
         r = evaluation_script.evaluate("testfiles/ground_truth_set2.tsv",
                                        "testfiles/predictions_set2d.tsv", "supervised")
         rdata = r['result'][0]['data']
@@ -182,26 +182,26 @@ class TestPredictions(unittest.TestCase):
                                                        "testfiles/predictions_set2d.tsv",
                                                        "testfiles/documents_set2.tsv")
         for k, v in expected.items():
-            if k != 'average_l2h_ndcg@10' and k != 'average_h2l_ndcg@10':
+            if k != 'l2h_ndcg10' and k != 'h2l_ndcg10':
                 self.assertAlmostEqual(v, rdata[k])
                 self.assertAlmostEqual(v, rdata2[k])
             self.assertAlmostEqual(v, rdata3[k])
 
     def test_g2_p2e(self):
-        expected = {'global_precision': 0.375,
-                    'global_recall': 0.375,
-                    'global_f1': 0.375,
-                    'global_tpr': 0.375,
-                    'global_fpr': 0.625,
-                    'global_accuracy': 0.375,
-                    'average_precision': 0.342857143,
-                    'average_recall': 0.428571429,
-                    'average_f1': 0.285714286,
-                    'average_tpr': 0.428571429,
-                    'average_fpr': 0.714285714,
-                    'average_accuracy': 0.34523809523809523,
-                    'average_l2h_ndcg@10': 0.36866848828077303,
-                    'average_h2l_ndcg@10': 0.4462728422747134,
+        expected = {'precision': 0.375,
+                    'recall': 0.375,
+                    'f1': 0.375,
+                    'tpr': 0.375,
+                    'fpr': 0.625,
+                    'accuracy': 0.375,
+                    'ave_precision': 0.342857143,
+                    'ave_recall': 0.428571429,
+                    'ave_f1': 0.285714286,
+                    'ave_tpr': 0.428571429,
+                    'ave_fpr': 0.714285714,
+                    'ave_accuracy': 0.34523809523809523,
+                    'l2h_ndcg10': 0.36866848828077303,
+                    'h2l_ndcg10': 0.4462728422747134,
         }
 
         r = evaluation_script.evaluate("testfiles/ground_truth_set2.tsv",
@@ -213,26 +213,26 @@ class TestPredictions(unittest.TestCase):
                                                        "testfiles/predictions_set2e.tsv",
                                                        "testfiles/documents_set2.tsv")
         for k, v in expected.items():
-            if k != 'average_l2h_ndcg@10' and k != 'average_h2l_ndcg@10':
+            if k != 'l2h_ndcg10' and k != 'h2l_ndcg10':
                 self.assertAlmostEqual(v, rdata[k])
                 self.assertAlmostEqual(v, rdata2[k])
             self.assertAlmostEqual(v, rdata3[k])
 
     def test_g3_p3a(self):
-        expected = {'global_precision': 0.6923076923076923,
-                    'global_recall': 0.75,
-                    'global_f1': 0.7199999999999999,
-                    'global_tpr': 0.75,
-                    'global_fpr': 0.34285714285714286,
-                    'global_accuracy': 0.704225352112676,
-                    'average_precision': 0.7517857142857143,
-                    'average_recall': 0.7547619047619047,
-                    'average_f1': 0.7340659340659341,
-                    'average_tpr': 0.7547619047619047,
-                    'average_fpr': 0.3625,
-                    'average_accuracy': 0.7050369769119769,
-                    'average_l2h_ndcg@10': 0.5995043313788928,
-                    'average_h2l_ndcg@10': 0.8314918192086054,
+        expected = {'precision': 0.6923076923076923,
+                    'recall': 0.75,
+                    'f1': 0.7199999999999999,
+                    'tpr': 0.75,
+                    'fpr': 0.34285714285714286,
+                    'accuracy': 0.704225352112676,
+                    'ave_precision': 0.7517857142857143,
+                    'ave_recall': 0.7547619047619047,
+                    'ave_f1': 0.7340659340659341,
+                    'ave_tpr': 0.7547619047619047,
+                    'ave_fpr': 0.3625,
+                    'ave_accuracy': 0.7050369769119769,
+                    'l2h_ndcg10': 0.5995043313788928,
+                    'h2l_ndcg10': 0.8314918192086054,
         }
 
         r = evaluation_script.evaluate("testfiles/ground_truth_set3.tsv",
@@ -244,26 +244,26 @@ class TestPredictions(unittest.TestCase):
                                                        "testfiles/predictions_set3a.tsv",
                                                        "testfiles/documents_set3.tsv")
         for k, v in expected.items():
-            if k != 'average_l2h_ndcg@10' and k != 'average_h2l_ndcg@10':
+            if k != 'l2h_ndcg10' and k != 'h2l_ndcg10':
                 self.assertAlmostEqual(v, rdata[k])
                 self.assertAlmostEqual(v, rdata2[k])
             self.assertAlmostEqual(v, rdata3[k])
 
     def test_g3_p3b(self):
-        expected = {'global_precision': 0.5333333333333333,
-                    'global_recall': 0.4444444444444444,
-                    'global_f1': 0.4848484848484848,
-                    'global_tpr': 0.4444444444444444,
-                    'global_fpr': 0.4,
-                    'global_accuracy': 0.5211267605633803,
-                    'average_precision': 0.5708333333333334,
-                    'average_recall': 0.4857142857142857,
-                    'average_f1': 0.4978174603174603,
-                    'average_tpr': 0.4857142857142857,
-                    'average_fpr': 0.39166666666666666,
-                    'average_accuracy': 0.5315205627705628,
-                    'average_l2h_ndcg@10': 0.3287689269825538,
-                    'average_h2l_ndcg@10': 0.5639633827558276,
+        expected = {'precision': 0.5333333333333333,
+                    'recall': 0.4444444444444444,
+                    'f1': 0.4848484848484848,
+                    'tpr': 0.4444444444444444,
+                    'fpr': 0.4,
+                    'accuracy': 0.5211267605633803,
+                    'ave_precision': 0.5708333333333334,
+                    'ave_recall': 0.4857142857142857,
+                    'ave_f1': 0.4978174603174603,
+                    'ave_tpr': 0.4857142857142857,
+                    'ave_fpr': 0.39166666666666666,
+                    'ave_accuracy': 0.5315205627705628,
+                    'l2h_ndcg10': 0.3287689269825538,
+                    'h2l_ndcg10': 0.5639633827558276,
         }
 
         r = evaluation_script.evaluate("testfiles/ground_truth_set3.tsv",
@@ -275,26 +275,26 @@ class TestPredictions(unittest.TestCase):
                                                        "testfiles/predictions_set3b.tsv",
                                                        "testfiles/documents_set3.tsv")
         for k, v in expected.items():
-            if k != 'average_l2h_ndcg@10' and k != 'average_h2l_ndcg@10':
+            if k != 'l2h_ndcg10' and k != 'h2l_ndcg10':
                 self.assertAlmostEqual(v, rdata[k])
                 self.assertAlmostEqual(v, rdata2[k])
             self.assertAlmostEqual(v, rdata3[k])
 
     def test_g3_p3c(self):
-        expected = {'global_precision': 0.5675675675675675,
-                    'global_recall': 0.5833333333333334,
-                    'global_f1': 0.5753424657534246,
-                    'global_tpr': 0.5833333333333334,
-                    'global_fpr': 0.45714285714285713,
-                    'global_accuracy': 0.5633802816901409,
-                    'average_precision': 0.5708333333333333,
-                    'average_recall': 0.5851190476190475,
-                    'average_f1': 0.5680826118326119,
-                    'average_tpr': 0.5851190476190475,
-                    'average_fpr': 0.4125,
-                    'average_accuracy': 0.5734397546897546,
-                    'average_l2h_ndcg@10': 0.561254350448992,
-                    'average_h2l_ndcg@10': 0.5824553461136641,
+        expected = {'precision': 0.5675675675675675,
+                    'recall': 0.5833333333333334,
+                    'f1': 0.5753424657534246,
+                    'tpr': 0.5833333333333334,
+                    'fpr': 0.45714285714285713,
+                    'accuracy': 0.5633802816901409,
+                    'ave_precision': 0.5708333333333333,
+                    'ave_recall': 0.5851190476190475,
+                    'ave_f1': 0.5680826118326119,
+                    'ave_tpr': 0.5851190476190475,
+                    'ave_fpr': 0.4125,
+                    'ave_accuracy': 0.5734397546897546,
+                    'l2h_ndcg10': 0.561254350448992,
+                    'h2l_ndcg10': 0.5824553461136641,
         }
 
         r = evaluation_script.evaluate("testfiles/ground_truth_set3.tsv",
@@ -306,11 +306,11 @@ class TestPredictions(unittest.TestCase):
                                                        "testfiles/predictions_set3c.tsv",
                                                        "testfiles/documents_set3.tsv")
         for k, v in expected.items():
-            if k != 'average_l2h_ndcg@10' and k != 'average_h2l_ndcg@10':
+            if k != 'l2h_ndcg10' and k != 'h2l_ndcg10':
                 self.assertAlmostEqual(v, rdata[k])
                 self.assertAlmostEqual(v, rdata2[k])
             self.assertAlmostEqual(v, rdata3[k])
 
-            
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR renames the metrics to match what is needed for the evalAI leaderboard. For logistical reasons, the earlier names used for the global metrics need to be retained. For this reason, `recall`, `precision`, `f1`, etc., are used to refer to the global metrics. The query average metrics have the same names, except for having an `ave_` prefix. (Using `ave_` rather than `average_` is to save space on the UX.) The NDCG metrics have also been renamed to be more succinct.